### PR TITLE
sec_cmd: instead of passing nonsense string just prevent abusing strncat

### DIFF
--- a/drivers/input/sec_cmd.c
+++ b/drivers/input/sec_cmd.c
@@ -61,8 +61,6 @@ void sec_cmd_set_default_result(struct sec_cmd_data *data)
 
 void sec_cmd_set_cmd_result_all(struct sec_cmd_data *data, char *buff, int len, char *item)
 {
-	char delim1 = ' ';
-	char delim2 = ':';
 	int cmd_result_len;
 
 	cmd_result_len = (int)strlen(data->cmd_result_all) + len + 2 + (int)strlen(item);
@@ -73,9 +71,9 @@ void sec_cmd_set_cmd_result_all(struct sec_cmd_data *data, char *buff, int len, 
 	}
 
 	data->item_count++;
-	strncat(data->cmd_result_all, &delim1, 1);
+	strcat(data->cmd_result_all, " ");
 	strncat(data->cmd_result_all, item, strlen(item));
-	strncat(data->cmd_result_all, &delim2, 1);
+	strcat(data->cmd_result_all, ":");
 	strncat(data->cmd_result_all, buff, len);
 }
 


### PR DESCRIPTION
it's based on sultan's [commit](https://github.com/THEBOSS619/Note9-Zeus-Q10.0/commit/d456e8dc719904baa24b3bc5cd6c948451e9a327) logic