### PR TITLE
crypto/pcbc: fix ELS repo mismerge mistake

### DIFF
--- a/crypto/pcbc.c
+++ b/crypto/pcbc.c
@@ -14,7 +14,6 @@
  *
  */
 
-#include <crypto/algapi.h>
 #include <linux/err.h>
 #include <linux/init.h>
 #include <linux/kernel.h>


### PR DESCRIPTION
according to https://patchwork.kernel.org/patch/9440913/