### PR TITLE
exynos-hp: increase drivers priority for consistent hotplug performance

### DIFF
--- a/drivers/soc/samsung/exynos-hotplug_governor.c
+++ b/drivers/soc/samsung/exynos-hotplug_governor.c
@@ -423,6 +423,8 @@ static void __exynos_hpgov_set_disable(void)
 
 static void __exynos_hpgov_set_enable(void)
 {
+	struct sched_param param;
+
 	exynos_hpgov.mode = QUAD;
 	exynos_hpgov.user_mode = DISABLE;
 	exynos_hpgov.req_cpu_min = PM_QOS_CPU_ONLINE_MAX_DEFAULT_VALUE;
@@ -439,7 +441,8 @@ static void __exynos_hpgov_set_enable(void)
 		return;
 	}
 
-	set_user_nice(exynos_hpgov.task, MIN_NICE);
+	param.sched_priority = 20;
+	sched_setscheduler_nocheck(exynos_hpgov.task, SCHED_FIFO, &param);
 	set_cpus_allowed_ptr(exynos_hpgov.task, cpu_coregroup_mask(0));
 
 	if (exynos_hpgov.task)


### PR DESCRIPTION
this is obviously a performance critical driver for our device... let's make sure it have max priority.